### PR TITLE
Fix: Prevent environment file from being created with root permissions in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN pip install uv
 
 COPY . .
 
-CMD ["/bin/bash", "-c", "cp .env.example .env && uv sync && uv run main.py"]
+CMD ["/bin/bash", "-c", "uv sync && uv run main.py"]
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ uv run main.py
 
 For easier deployment and environment consistency, you can run this application using Docker.
 
+### Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
 ### Prerequisites for Docker
 
 - **Docker Desktop**: Make sure you have Docker Desktop installed on your system. You can download it from https://www.docker.com/products/docker-desktop/ or https://docs.docker.com/engine/install/ for linux.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,5 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
-    command: /bin/bash -c "cp .env.example .env && uv sync && uv run main.py"
+    command: /bin/bash -c "uv sync && uv run main.py"
     restart: unless-stopped
-
-
-


### PR DESCRIPTION
This PR addresses an issue where the environment file (.env) was being created inside the Docker container with root ownership. This resulted in permission issues, making it difficult to modify the file from the host system.

Changes made:

- Adjusted Docker configuration to avoid generating .env as root