### PR TITLE
Feature/issue 29 create affirmation routes

### DIFF
--- a/app/controllers/root.py
+++ b/app/controllers/root.py
@@ -60,7 +60,9 @@ def affirmations():
     Affirmations page.
     """
     all_affirmations: List[Affirmation] = Affirmation.query.all()
-    return render_template("affirmations/index.html", all_affirmations=all_affirmations)
+    return render_template(
+        "affirmations/index.html", all_affirmations=all_affirmations, user=current_user
+    )
 
 
 @root_bp.route("/affirmations/add", methods=["GET", "POST"])
@@ -108,3 +110,15 @@ def edit_affirmation(affirmation_id):
         return redirect(url_for("root.affirmations"))
 
     return render_template("affirmations/edit.html", affirmation=affirmation)
+
+
+@root_bp.post("/affirmations/delete/<int:affirmation_id>")
+@login_required
+def delete_affirmation(affirmation_id):
+    affirmation = Affirmation.query.get_or_404(affirmation_id)
+    if affirmation.user_id == current_user.user_id:
+        db.session.delete(affirmation)
+        db.session.commit()
+        flash("Affirmation deleted", "success")
+
+    return redirect(url_for("root.affirmations"))

--- a/app/controllers/root.py
+++ b/app/controllers/root.py
@@ -51,3 +51,12 @@ def admin_dashboard():
         all_users=all_users,
         all_affirmations=all_affirmations,
     )
+
+
+@root_bp.route("/affirmations")
+def affirmations():
+    """
+    Affirmations page.
+    """
+    all_affirmations: List[Affirmation] = Affirmation.query.all()
+    return render_template("affirmations/index.html", all_affirmations=all_affirmations)

--- a/app/controllers/root.py
+++ b/app/controllers/root.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from typing import List
 
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request, flash, redirect, url_for
 from flask_login import login_required, current_user
 
+from app import db
 from app.models import User, Affirmation
 
 root_bp = Blueprint("root", __name__)
@@ -60,3 +61,27 @@ def affirmations():
     """
     all_affirmations: List[Affirmation] = Affirmation.query.all()
     return render_template("affirmations/index.html", all_affirmations=all_affirmations)
+
+
+@root_bp.route("/affirmations/add", methods=["GET", "POST"])
+@login_required
+def add_affirmation():
+    """
+    Add an affirmation
+    """
+    if request.method == "POST":
+        text: str | None = request.form.get("affirmation_text")
+
+        if not text:
+            flash("Please type your affirmation", "error")
+            return render_template("affirmations/add.html")
+
+        affirmation = Affirmation(affirmation_text=text, user_id=current_user.user_id)
+
+        db.session.add(affirmation)
+        db.session.commit()
+
+        flash("Your affirmation have been added", "success")
+        return redirect(url_for("root.affirmations"))
+
+    return render_template("affirmations/add.html")

--- a/app/controllers/root.py
+++ b/app/controllers/root.py
@@ -85,3 +85,26 @@ def add_affirmation():
         return redirect(url_for("root.affirmations"))
 
     return render_template("affirmations/add.html")
+
+
+@root_bp.route("/affirmations/edit/<int:affirmation_id>", methods=["GET", "POST"])
+@login_required
+def edit_affirmation(affirmation_id):
+    affirmation = Affirmation.query.get_or_404(affirmation_id)
+    if affirmation.user_id != current_user.user_id:
+        flash("Can not edit others affirmation", "error")
+        return redirect(url_for("root.affirmations"))
+
+    if request.method == "POST":
+        textInput: str | None = request.form.get("affirmation_text")
+
+        if not textInput:
+            return render_template("affirmations/edit.html", affirmation=affirmation)
+
+        affirmation.affirmation_text = textInput
+        db.session.commit()
+
+        flash("Affirmation updated", "success")
+        return redirect(url_for("root.affirmations"))
+
+    return render_template("affirmations/edit.html", affirmation=affirmation)

--- a/app/templates/affirmations/add.html
+++ b/app/templates/affirmations/add.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %} {% block title %} Affirmations {% endblock %} {% block
+content %}
+
+<form method="POST" action="{{ url_for('root.add_affirmation') }}">
+  <p><label for="affirmation_text">Affirmation:</label></p>
+  <textarea
+    id="affirmation_text"
+    name="affirmation_text"
+    rows="4"
+    cols="50"
+    required
+  >
+Add your affirmation here</textarea
+  >
+  <br />
+
+  <button type="submit">Submit</button>
+</form>
+
+<p>
+  See all affirmations <a href="{{ url_for('root.affirmations') }}">here</a>
+</p>
+
+{% endblock %}

--- a/app/templates/affirmations/edit.html
+++ b/app/templates/affirmations/edit.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %} {% block title %} Affirmations {% endblock %} {% block
+content %}
+
+<form
+  method="POST"
+  action="{{ url_for('root.edit_affirmation', affirmation_id=affirmation.affirmation_id) }}"
+>
+  <p><label for="affirmation_text">Affirmation:</label></p>
+  <textarea
+    id="affirmation_text"
+    name="affirmation_text"
+    rows="4"
+    cols="50"
+    required
+  >
+{{ affirmation.affirmation_text }}</textarea
+  >
+  <br />
+
+  <button type="submit">Edit</button>
+</form>
+
+{% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -6,8 +6,16 @@ content %}
 <p>
   <a
     href="{{ url_for('root.edit_affirmation', affirmation_id=affirmation.affirmation_id)}}"
-    >{{ affirmation.affirmation_text }}</a
-  >
+    >{{ affirmation.affirmation_text }} 
+  </a>
+    {% if affirmation.user_id == user.user_id %}
+    <form
+      method="POST"
+      action="{{ url_for('root.delete_affirmation', affirmation_id=affirmation.affirmation_id) }}"
+    >
+      <button type="submit">Delete</button>
+    </form>
+    {% endif %}
 </p>
 {% endfor %}
 <p>Add affirmation <a href="{{ url_for('root.add_affirmation') }}">here</a></p>

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %} {% block title %} Affirmations {% endblock %} {% block
+content %}
+<h1>Affirmations</h1>
+
+{% for affirmation in all_affirmations %} {{ affirmation.affirmation_text }}
+<br />
+{% endfor %} {% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -2,8 +2,13 @@
 content %}
 <h1>Affirmations</h1>
 
-{% for affirmation in all_affirmations %} {{ affirmation.affirmation_text }}
-<br />
+{% for affirmation in all_affirmations %}
+<p>
+  <a
+    href="{{ url_for('root.edit_affirmation', affirmation_id=affirmation.affirmation_id)}}"
+    >{{ affirmation.affirmation_text }}</a
+  >
+</p>
 {% endfor %}
 <p>Add affirmation <a href="{{ url_for('root.add_affirmation') }}">here</a></p>
 {% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -4,4 +4,6 @@ content %}
 
 {% for affirmation in all_affirmations %} {{ affirmation.affirmation_text }}
 <br />
-{% endfor %} {% endblock %}
+{% endfor %}
+<p>Add affirmation <a href="{{ url_for('root.add_affirmation') }}">here</a></p>
+{% endblock %}


### PR DESCRIPTION
## What?

I've implemented routes for Affirmations CRUD operations. It included simple Jinja templates for listing affirmations and editing each affirmation. For more background, see [issue 29](https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class/issues/29).

## Why?

These changes are needed for affirmations's management.

## How?

I added the routes in `root.py` file and created the templates inside `affirmations` folder.

## Testing?

- Go to `localhost:8000/affirmations`.
- Click any affirmation if you want to edit, and click `Delete` button if you want to delete. 
- Only `current_user`'s affirmation can be edited or deleted.
- Every CRUD operations will redirect `current_user` to `localhost:8000/affirmations`

## Anything Else?

I forgot to add profanity filter when creating an affirmation.