### PR TITLE
Fix: Logout from dropdown + relative units for paddings and margins

### DIFF
--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -1,6 +1,7 @@
 * {
   box-sizing: border-box;
   margin: 0;
+  padding: 0;
 }
 
 :root {
@@ -16,7 +17,7 @@
 
 body {
   min-height: 100vh;
-  margin: 50px 0 0 0;
+  margin: 2.5rem 0 0 0;
   background-color: var(--body-bg-clr);
   display: flex;
   flex-direction: column;
@@ -33,7 +34,7 @@ main {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 20px 20px;
+  padding: 1.5rem 1.5rem;
 }
 
 /* Mobile-first design - minimum 300px screen width */
@@ -44,12 +45,13 @@ main {
   justify-content: center;
   background-color: var(--purple-dark);
   color: white;
-  height: 50px;
   width: 100%;
+  height: 3.5rem;
   text-align: center;
   align-items: center;
   font-size: 0.8rem;
   overflow: visible;
+  padding: 0.3rem;
 }
 
 .nav__menu {
@@ -72,18 +74,12 @@ main {
 }
 
 .nav__img {
-  height: 40px;
-  padding: 5px 10px 0 10px;
-  position: relative;
+  height: 2.5rem;
+  margin: 0 0.5rem;
 }
 
 .nav__logo {
-  height: 40px;
-  padding: 5px 0 0 0;
-  margin: 0 15px;
-  position: absolute;
-  left: 0;
-  top: 0;
+  height: 2.5rem;
 }
 
 #nav__dropdown {
@@ -92,9 +88,9 @@ main {
   flex-direction: column;
   background-color: var(--purple-dark);
   width: 40vw;
-  max-width: 150px;
+  max-width: 10rem;
   position: absolute;
-  top: 50px;
+  top: 3.5rem;
   right: 0;
   text-align: right;
 }
@@ -106,7 +102,7 @@ main {
 .nav__menu--button {
   text-decoration: none;
   color: white;
-  padding: 10px;
+  padding: 0.8rem;
   height: inherit;
 }
 
@@ -117,10 +113,6 @@ main {
 a.nav__menu--button.active {
   background-color: #8B66C6;
   font-weight: bold;
-}
-
-.nav__menu--button:not(#nav__dropdown > .nav__menu--button) {
-  padding-top: 15px;
 }
 
 .logout {
@@ -134,7 +126,7 @@ a.nav__menu--button.active {
 footer {
   background-color: var(--purple-dark);
   width: 100%;
-  padding: 30px 5vw;
+  padding: 1.8rem 5vw;
   text-align: center;
   position: relative;
   bottom: 0;
@@ -145,8 +137,8 @@ footer {
   background-color: white;
   border: 3px var(--purple-outline) solid;
   border-radius: 20px;
-  padding: 15px;
-  margin-bottom: 20px;
+  padding: 1rem;
+  margin-bottom: 1.2rem;
 }
 
 .footer__register--slogan {
@@ -170,7 +162,7 @@ footer {
   font-weight: bold;
   text-decoration: none;
   color: white;
-  padding: 15px;
+  padding: 1rem;
 }
 
 .login__prompt {
@@ -184,8 +176,8 @@ footer {
 }
 
 .footer__logo {
-  height: 30px;
-  margin: 0 15px -10px 15px;
+  height: 2rem;
+  margin: 0 1rem -0.8rem 1rem;
 }
 
 .footer__totop--button {
@@ -194,13 +186,13 @@ footer {
   border: none;
   font-size: 0.8rem;
   color: white;
-  padding: 10px;
+  padding: 0.8rem;
 }
 
 address {
   font-size: 0.6rem;
   color: var(--purple-outline);
-  margin: 20px 0 0 0;
+  margin: 1.2rem 0 0 0;
 }
 
 address a {

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -76,10 +76,14 @@ main {
 .nav__img {
   height: 2.5rem;
   margin: 0 0.5rem;
+  position: relative;
 }
 
 .nav__logo {
   height: 2.5rem;
+  position: absolute;
+  top: 0.5rem;
+  left: 1.5rem;
 }
 
 #nav__dropdown {
@@ -207,5 +211,7 @@ button {
 @media only screen and (min-width: 600px) {
   .nav__logo {
     position: relative;
+    top: 0;
+    left: 0;
   }
 }

--- a/app/templates/_header.html
+++ b/app/templates/_header.html
@@ -13,7 +13,7 @@
       <a href="{{ url_for('root.admin_dashboard') }}" class="nav__menu--button{% if request.path == url_for('root.admin_dashboard') %} active{% endif %}">Categories</a>
       <a href="{{ url_for('root.admin_dashboard') }}" class="nav__menu--button{% if request.path == url_for('root.admin_dashboard') %} active{% endif %}">Affirmations</a>
       <a href="{{ url_for('root.admin_dashboard') }}" class="nav__menu--button{% if request.path == url_for('root.admin_dashboard') %} active{% endif %}">Settings</a>
-      <a href="#logout" class="nav__menu--button logout">Logout</a>
+      <a href="{{ url_for('auth.logout') }}" class="nav__menu--button logout">Logout</a>
     </div>
     {% elif current_user.is_authenticated %}
     <div class="nav__menu">
@@ -27,7 +27,7 @@
       <a href="{{ url_for('root.index') }}" class="nav__menu--button{% if request.path == url_for('root.index') %} active{% endif %}">Home</a>
       <a href="{{ url_for('root.dashboard') }}" class="nav__menu--button{% if request.path == url_for('root.dashboard') %} active{% endif %}">Dashboard</a>
       <a href="{{ url_for('auth.profile') }}" class="nav__menu--button{% if request.path == url_for('auth.profile') %} active{% endif %}">User Settings</a>
-      <a href="#logout" class="nav__menu--button logout">Logout</a>
+      <a href="{{ url_for('auth.logout') }}" class="nav__menu--button logout">Logout</a>
     </nav>
     {% elif request.path == url_for('auth.login') %}
     <div class="nav__menu">


### PR DESCRIPTION
Closes #47 - logout from dropdown menu should work now

In addition, all paddings and margins should be in relative units (rem, %...) rather than fixed units (px) now. Same applies for certain widths and heights as well.