### PR TITLE
fix:  is_admin() method returns True if the user has an admin role

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -35,7 +35,7 @@ class User(db.Model, UserMixin):
 
     def is_admin(self):
         """Check if the user is an admin."""
-        return self.roles.filter(Role.name == "admin").first() is not None
+        return any(role.name == "admin" for role in self.roles)
 
 
 class Role(db.Model):


### PR DESCRIPTION

**fix:** Updated the `is_admin` method to use Python’s `any()` for checking roles instead of using the `.filter().first()` approach.

```diff
def is_admin(self):
    """Check if the user is an admin."""
++  return any(role.name == "admin" for role in self.roles)
--  return  self.roles.filter(Role.name == "admin").first() is not None
```
   
**reason:** The previous method wasn’t working as intended with the current data structure. This fix ensures it checks all roles properly for the admin role.