### PR TITLE
bugfix; differentiate header for admin and user roles

### DIFF
--- a/app/templates/_header.html
+++ b/app/templates/_header.html
@@ -1,7 +1,7 @@
 <header>
   <nav class="nav__top">
     <a href="{{ url_for('root.index') }}"><img src="{{ url_for('static', filename='images/logo_white.svg') }}" alt="DailyDose logo" class="nav__logo"></a>
-    {% if current_user.is_authenticated and current_user.is_admin %}
+    {% if current_user.is_authenticated and current_user.is_admin() %}
     <div class="nav__menu">
       <button onclick="navDropdown()" class="nav__name">Admin</button>
       <button onclick="navDropdown()">


### PR DESCRIPTION
Fixed the header where admin and user roles display the same header with the correct call for is_admin method
Resolves issue#52