### PR TITLE
Fix registration form error: missing 'name' field

### DIFF
--- a/app/controllers/auth.py
+++ b/app/controllers/auth.py
@@ -63,14 +63,20 @@ def register() -> Union[str, Response]:
 
     if request.method == "POST":
         # read form data
-        name: str = request.form.get("name")
+        name: str = request.form.get("first_name") + " " + request.form.get("last_name")
         username: str = request.form.get("username")
         email: str = request.form.get("email")
         password: str = request.form.get("password")
         is_email_opt_in: bool = request.form.get("is_email_opt_in") == "on"
 
         # validate required fields
-        required_fields: list[str] = ["name", "username", "email", "password"]
+        required_fields: list[str] = [
+            "first_name",
+            "last_name",
+            "username",
+            "email",
+            "password",
+        ]
         for field in required_fields:
             if not request.form.get(field):
                 flash(f"Missing required field: {field}", "error")


### PR DESCRIPTION
This PR resolves an issue where the registration form fails to submit, returning the error:

`Missing required field: name`

Although users correctly fill in both first_name and last_name, the backend expects a name field that is not present in the form.

**Fix**

- Updated the registration back-end to combine first_name and last_name into a single name field and added the same fields to the list of required fields to be validated before creating the user.