### PR TITLE
fix(home): Use Jinja for loop to display affirmations on the home page

### DIFF
--- a/app/controllers/root.py
+++ b/app/controllers/root.py
@@ -15,11 +15,14 @@ def index():
     """
     Main landing page.
     """
+    all_affirmations: List[Affirmation] = Affirmation.query.all()
 
     return render_template(
         "home/index.html",
         title="DailyDose",
         current_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        user=current_user,
+        all_affirmations=all_affirmations,
     )
 
 

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -25,11 +25,11 @@ content %}
 <section class="home__section home__affirms">
   <h2>Today's Affirmation</h2>
   <div class="affirms__wrapper">
-    <!-- We may use Jinja for loop for displaying affirmations -->
+    {% for affirmation in all_affirmations[:3] %}
     <div class="affirm">
       <figure class="affirm__wrapper">
         <blockquote class="affirm__quote">
-          I am present in the moment and embrace it fully.
+          {{ affirmation.affirmation_text }}
         </blockquote>
         <!-- We may use Jinja for loop for displaying the categories of this affirmation -->
         <figcaption class="affirm__cats">Self Care, Emotion</figcaption>
@@ -45,26 +45,7 @@ content %}
         </p>
       </div>
     </div>
-
-    <div class="affirm">
-      <figure class="affirm__wrapper">
-        <blockquote class="affirm__quote">
-          I trust in my inner wisdom.
-        </blockquote>
-        <!-- We may use Jinja for loop for displaying the categories of this affirmation -->
-        <figcaption class="affirm__cats">Self Worth</figcaption>
-      </figure>
-      <div class="affirm__btn--wrapper">
-        <button class="affirm__btn" aria-label="Save affirmation">+</button>
-        <p>
-          {% if current_user.is_authenticated %}
-            Save this affirmation
-          {% else %}
-            <a href="{{ url_for('auth.login') }}">Log in</a> to save this affirmation
-          {% endif %}
-        </p>
-      </div>
-    </div>
+    {% endfor %}    
   </div>
 </section>
 
@@ -80,7 +61,7 @@ content %}
       <blockquote class="affirm__quote">
         I trust in my inner wisdom.
       </blockquote>
-    <figcaption class="affirm__cats">Self Worth</figcaption>
+      <figcaption class="affirm__cats">Self Worth</figcaption>
     </figure>
     <button class="home__btn">Get Affirmation</button>
   </div>

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -57,12 +57,14 @@ content %}
     <a class="home__btn" href="#">Submit Affirmations</a>
   </div>
   <div class="home__section">
+    {% for affirmation in all_affirmations[:1] %} 
     <figure class="affirm__wrapper">
       <blockquote class="affirm__quote">
-        I trust in my inner wisdom.
+        {{ affirmation.affirmation_text }}
       </blockquote>
       <figcaption class="affirm__cats">Self Worth</figcaption>
     </figure>
+    {% endfor %}
     <button class="home__btn">Get Affirmation</button>
   </div>
 </section>


### PR DESCRIPTION
Resolves https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class/issues/55

Replaces the hardcoded affirmations on the home page with Jinja code, by using for loops to display affirmations.