### PR TITLE
Feat/reset passowrd and minor improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,13 @@ FLASK_DEBUG=False
 
 SECRET_KEY=your-cool-secret-key
 
-DATABASE_URL=postgresql://user:password@localhost/dbname #postgresql
+DATABASE_URL=postgresql://user:password@localhost/dbname
+
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USERNAME=your-email@gmail.com 
+MAIL_PASSWORD=your-app-password
+MAIL_USE_TLS=True
+MAIL_USE_SSL=False
+MAIL_DEFAULT_SENDER=your-email@gmail.com
+# guide to get gmail app password: https://mailtrap.io/blog/flask-send-email-gmail/

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 exclude = 
     .git,
     __pycache__,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,8 +3,15 @@ import os
 
 from flask import Flask, jsonify
 from flask_login import LoginManager
+from flask_mail import Mail
 
 from app.models import User, db
+
+import dotenv
+
+dotenv.load_dotenv()
+
+mail = Mail()
 
 
 def create_app():
@@ -12,12 +19,20 @@ def create_app():
     Main entry point for the web application.
     """
     app = Flask(__name__)
-
     app.config.from_mapping(
         SECRET_KEY=os.environ.get("SECRET_KEY", "dev"),
         SQLALCHEMY_DATABASE_URI=os.environ.get("DATABASE_URL"),
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        MAIL_SERVER=os.environ.get("MAIL_SERVER"),
+        MAIL_PORT=int(os.environ.get("MAIL_PORT", 587)),
+        MAIL_USERNAME=os.environ.get("MAIL_USERNAME"),
+        MAIL_DEFAULT_SENDER=os.environ.get("MAIL_DEFAULT_SENDER"),
+        MAIL_PASSWORD=os.environ.get("MAIL_PASSWORD"),
+        MAIL_USE_TLS=os.environ.get("MAIL_USE_TLS", "False").lower() == "true",
+        MAIL_USE_SSL=os.environ.get("MAIL_USE_SSL", "False").lower() == "true",
     )
+
+    mail.init_app(app)
 
     app.static_folder = "static"
     app.template_folder = "templates"
@@ -36,9 +51,11 @@ def create_app():
 
     from .controllers.root import root_bp
     from .controllers.auth import auth_bp
+    from .controllers.affirmations import affirmations_bp
 
     app.register_blueprint(root_bp)
     app.register_blueprint(auth_bp)
+    app.register_blueprint(affirmations_bp)
 
     @app.route("/health")
     def health_check():

--- a/app/controllers/affirmations.py
+++ b/app/controllers/affirmations.py
@@ -1,0 +1,136 @@
+from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+from typing import List
+from sqlalchemy import func
+
+from app import db
+from app.models import Affirmation, SavedAffirmation
+
+affirmations_bp = Blueprint("affirmations", __name__)
+
+
+@affirmations_bp.route("/affirmations")
+def affirmations():
+    """
+    Affirmations page.
+    """
+    all_affirmations: List[Affirmation] = Affirmation.query.all()
+    return render_template(
+        "affirmations/index.html", all_affirmations=all_affirmations, user=current_user
+    )
+
+
+@affirmations_bp.route("/affirmations/random", methods=["GET"])
+def random_affirmation():
+    """
+    Affirmations page.
+    """
+    random_affirmation: Affirmation = Affirmation.query.order_by(func.random()).first()
+    return jsonify({"affirmation": random_affirmation.affirmation_text})
+
+
+@affirmations_bp.route("/affirmations/add", methods=["GET", "POST"])
+@login_required
+def add_affirmation():
+    """
+    Add an affirmation
+    """
+    if request.method == "POST":
+        text: str | None = request.form.get("affirmation_text")
+
+        if not text:
+            flash("Please type your affirmation", "error")
+            return render_template("affirmations/add.html")
+
+        affirmation = Affirmation(affirmation_text=text, user_id=current_user.user_id)
+
+        db.session.add(affirmation)
+        db.session.commit()
+
+        flash("Your affirmation have been added", "success")
+        return redirect(url_for("affirmations.affirmations"))
+
+    return render_template("affirmations/add.html")
+
+
+@affirmations_bp.route(
+    "/affirmations/edit/<int:affirmation_id>", methods=["GET", "POST"]
+)
+@login_required
+def edit_affirmation(affirmation_id):
+    affirmation = Affirmation.query.get_or_404(affirmation_id)
+    if affirmation.user_id != current_user.user_id:
+        flash("Can not edit others affirmation", "error")
+        return redirect(url_for("affirmations.affirmations"))
+
+    if request.method == "POST":
+        textInput: str | None = request.form.get("affirmation_text")
+
+        if not textInput:
+            return render_template("affirmations/edit.html", affirmation=affirmation)
+
+        affirmation.affirmation_text = textInput
+        db.session.commit()
+
+        flash("Affirmation updated", "success")
+        return redirect(url_for("affirmations.affirmations"))
+
+    return render_template("affirmations/edit.html", affirmation=affirmation)
+
+
+@affirmations_bp.post("/affirmations/delete/<int:affirmation_id>")
+@login_required
+def delete_affirmation(affirmation_id):
+    affirmation = Affirmation.query.get_or_404(affirmation_id)
+    if affirmation.user_id == current_user.user_id:
+        db.session.delete(affirmation)
+        db.session.commit()
+        flash("Affirmation deleted", "success")
+
+    return redirect(url_for("affirmations.affirmations"))
+
+
+@affirmations_bp.route("/affirmations/save", methods=["POST"])
+@login_required
+def save_affirmation():
+    data = request.get_json()
+    affirmation_id = data.get("affirmationId")
+    if not affirmation_id:
+        return jsonify({"error": "No affirmation ID provided"}), 400
+
+    affirmation = Affirmation.query.get(affirmation_id)
+    if not affirmation:
+        return jsonify({"error": "Affirmation not found"}), 404
+
+    # Check if already saved
+    already_saved = SavedAffirmation.query.filter_by(
+        user_id=current_user.user_id, affirmation_id=affirmation_id
+    ).first()
+    if already_saved:
+        return jsonify({"message": "Already saved"}), 200
+
+    saved = SavedAffirmation(
+        user_id=current_user.user_id, affirmation_id=affirmation_id
+    )
+    db.session.add(saved)
+    db.session.commit()
+    return jsonify({"message": "Affirmation saved"}), 200
+
+
+@affirmations_bp.route("/affirmations/unsave", methods=["POST"])
+@login_required
+def unsave_affirmation():
+    data = request.get_json()
+    affirmation_id = data.get("affirmationId")
+    if not affirmation_id:
+        return jsonify({"error": "No affirmation ID provided"}), 400
+
+    saved = SavedAffirmation.query.filter_by(
+        user_id=current_user.user_id, affirmation_id=affirmation_id
+    ).first()
+    if not saved:
+        return jsonify({"error": "Affirmation not found"}), 404
+
+    db.session.delete(saved)
+    db.session.commit()
+    return jsonify({"message": "Affirmation unsaved"}), 200

--- a/app/controllers/auth.py
+++ b/app/controllers/auth.py
@@ -1,5 +1,4 @@
 from typing import Union
-
 import bcrypt
 from flask import (
     Blueprint,
@@ -9,13 +8,30 @@ from flask import (
     render_template,
     request,
     url_for,
+    current_app,
 )
 from flask_login import current_user, login_required, login_user, logout_user
+from itsdangerous import URLSafeTimedSerializer, SignatureExpired, BadSignature
+from flask_mail import Message
 
-from app import db
+from app import db, mail
 from app.models import Role, User
 
 auth_bp = Blueprint("auth", __name__)
+
+
+def generate_reset_token(user_email: str) -> str:
+    serializer = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
+    return serializer.dumps(user_email, salt="password-reset-salt")
+
+
+def verify_reset_token(token: str, expiration=3600) -> Union[str, None]:
+    serializer = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
+    try:
+        email = serializer.loads(token, salt="password-reset-salt", max_age=expiration)
+    except (SignatureExpired, BadSignature):
+        return None
+    return email
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
@@ -131,3 +147,96 @@ def logout() -> Response:
 @login_required
 def profile() -> str:
     return render_template("auth/profile.html", user=current_user)
+
+
+@auth_bp.route("/reset_password", methods=["GET", "POST"])
+def reset_password_request():
+    if current_user.is_authenticated:
+        return redirect(url_for("root.index"))
+    if request.method == "POST":
+        email = request.form.get("email")
+        if not email:
+            flash("Please enter your email address.", "error")
+            return render_template(
+                "auth/reset_password_request.html"
+            )  # TODO: make reset password request page
+        user = User.query.filter_by(email=email).first()
+        if user:
+            token = generate_reset_token(user.email)
+            reset_url = url_for(
+                "auth.reset_password_token", token=token, _external=True
+            )
+            msg = Message(
+                subject="Password Reset Request",
+                recipients=[user.email],
+                sender=current_app.config.get("MAIL_DEFAULT_SENDER"),
+            )
+            msg.body = f"""To reset your password, click the following link: {reset_url}
+                        \n\n
+                        If you did not request a password reset,
+                        please ignore this email.
+                       """
+            mail.send(msg)
+        # Always flash the same message to prevent user enumeration
+        flash(
+            "If an account with that email exists, a password reset link has been sent.",
+            "info",
+        )
+        return redirect(url_for("auth.login"))
+    return render_template(
+        "auth/reset_password_request.html"
+    )  # TODO: make reset password request page
+
+
+@auth_bp.route("/reset_password/<token>", methods=["GET", "POST"])
+def reset_password_token(token):
+    if current_user.is_authenticated:
+        return redirect(url_for("root.index"))
+    email = verify_reset_token(token)
+
+    if not email:
+        flash("The password reset link is invalid or has expired.", "error")
+        return redirect(url_for("auth.reset_password_request"))
+
+    if request.method == "POST":
+        password = request.form.get("password")
+        password2 = request.form.get("password2")
+
+        if not password or not password2:
+            flash("Please fill out both password fields.", "error")
+            return render_template(
+                "auth/reset_password.html", token=token
+            )  # TODO: make reset password page
+
+        if password != password2:
+            flash("Passwords do not match.", "error")
+            return render_template(
+                "auth/reset_password.html", token=token
+            )  # TODO: make reset password page
+        user = User.query.filter_by(email=email).first()
+
+        if not user:
+            flash("User not found.", "error")
+            return redirect(url_for("auth.reset_password_request"))
+
+        user.password_hash = bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt()
+        ).decode("utf-8")
+
+        db.session.commit()
+
+        flash("Your password has been reset. Please log in.", "success")
+        return redirect(url_for("auth.login"))
+    return render_template(
+        "auth/reset_password.html", token=token  # TODO: make reset password page
+    )
+
+
+# use this to send a reset password email
+# fetch("/reset_password", {
+#     method: "POST",
+#     headers: {
+#         "Content-Type": "application/json",
+#     },
+#     body: JSON.stringify({ email: "test@example.com" }),
+# });

--- a/app/controllers/root.py
+++ b/app/controllers/root.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 from typing import List
 
-from flask import Blueprint, render_template, request, flash, redirect, url_for
+from flask import Blueprint, render_template, redirect, url_for
 from flask_login import login_required, current_user
 
-from app import db
 from app.models import User, Affirmation
 
 root_bp = Blueprint("root", __name__)
@@ -45,6 +44,9 @@ def admin_dashboard():
     """
     Admin dashboard - requires authentication.
     """
+    if not current_user.is_admin():
+        return redirect(url_for("root.index"))
+
     all_users: List[User] = User.query.all()
     all_affirmations: List[Affirmation] = Affirmation.query.all()
 
@@ -55,73 +57,3 @@ def admin_dashboard():
         all_users=all_users,
         all_affirmations=all_affirmations,
     )
-
-
-@root_bp.route("/affirmations")
-def affirmations():
-    """
-    Affirmations page.
-    """
-    all_affirmations: List[Affirmation] = Affirmation.query.all()
-    return render_template(
-        "affirmations/index.html", all_affirmations=all_affirmations, user=current_user
-    )
-
-
-@root_bp.route("/affirmations/add", methods=["GET", "POST"])
-@login_required
-def add_affirmation():
-    """
-    Add an affirmation
-    """
-    if request.method == "POST":
-        text: str | None = request.form.get("affirmation_text")
-
-        if not text:
-            flash("Please type your affirmation", "error")
-            return render_template("affirmations/add.html")
-
-        affirmation = Affirmation(affirmation_text=text, user_id=current_user.user_id)
-
-        db.session.add(affirmation)
-        db.session.commit()
-
-        flash("Your affirmation have been added", "success")
-        return redirect(url_for("root.affirmations"))
-
-    return render_template("affirmations/add.html")
-
-
-@root_bp.route("/affirmations/edit/<int:affirmation_id>", methods=["GET", "POST"])
-@login_required
-def edit_affirmation(affirmation_id):
-    affirmation = Affirmation.query.get_or_404(affirmation_id)
-    if affirmation.user_id != current_user.user_id:
-        flash("Can not edit others affirmation", "error")
-        return redirect(url_for("root.affirmations"))
-
-    if request.method == "POST":
-        textInput: str | None = request.form.get("affirmation_text")
-
-        if not textInput:
-            return render_template("affirmations/edit.html", affirmation=affirmation)
-
-        affirmation.affirmation_text = textInput
-        db.session.commit()
-
-        flash("Affirmation updated", "success")
-        return redirect(url_for("root.affirmations"))
-
-    return render_template("affirmations/edit.html", affirmation=affirmation)
-
-
-@root_bp.post("/affirmations/delete/<int:affirmation_id>")
-@login_required
-def delete_affirmation(affirmation_id):
-    affirmation = Affirmation.query.get_or_404(affirmation_id)
-    if affirmation.user_id == current_user.user_id:
-        db.session.delete(affirmation)
-        db.session.commit()
-        flash("Affirmation deleted", "success")
-
-    return redirect(url_for("root.affirmations"))

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -28,6 +28,7 @@ class User(db.Model, UserMixin):
     roles = relationship("Role", secondary="user_roles", back_populates="users")
     affirmations = relationship("Affirmation", back_populates="user")
     daily_mail_history = relationship("DailyMailHistory", back_populates="user")
+    saved_affirmations = relationship("SavedAffirmation", back_populates="user")
 
     def get_id(self):
         """Return the user ID as a string for Flask-Login."""
@@ -102,6 +103,7 @@ class Affirmation(db.Model):
     user = relationship("User", back_populates="affirmations")
     categories = relationship("AffirmationCategory", back_populates="affirmation")
     daily_history = relationship("DailyMailHistory", back_populates="affirmation")
+    saved_affirmations = relationship("SavedAffirmation", back_populates="affirmation")
 
 
 class AffirmationCategory(db.Model):
@@ -145,3 +147,20 @@ class DailyMailHistory(db.Model):
 
     user = relationship("User", back_populates="daily_mail_history")
     affirmation = relationship("Affirmation", back_populates="daily_history")
+
+
+class SavedAffirmation(db.Model):
+    __tablename__ = "saved_affirmations"
+
+    saved_affirmation_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        Integer, ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False
+    )
+    affirmation_id = Column(
+        Integer,
+        ForeignKey("affirmations.affirmation_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    user = relationship("User", back_populates="saved_affirmations")
+    affirmation = relationship("Affirmation", back_populates="saved_affirmations")

--- a/app/static/scripts/index.js
+++ b/app/static/scripts/index.js
@@ -1,14 +1,41 @@
 // Toggle between showing and hiding the navigation menu links when the user clicks on the hamburger menu / bar icon
 function navDropdown() {
-    const navDropdown = document.getElementById("nav__dropdown");
-    if (navDropdown.style.visibility === "visible") {
-        navDropdown.style.visibility = "hidden";
-    } else {
-        navDropdown.style.visibility = "visible";
-    }
-  } 
+  const navDropdown = document.getElementById("nav__dropdown");
+  if (navDropdown.style.visibility === "visible") {
+    navDropdown.style.visibility = "hidden";
+  } else {
+    navDropdown.style.visibility = "visible";
+  }
+}
 
 // To top button in footer
 function toTop() {
-    window.scrollTo(0, 0);
-  } 
+  window.scrollTo(0, 0);
+}
+
+function saveAffirmation(affirmationId) {
+  fetch(`/affirmations/save`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ affirmationId }),
+  });
+}
+
+
+function getRandomAffirmation() {
+  const affirmationElement = document.getElementById("random-affirmation");
+  if (affirmationElement) {
+    affirmationElement.textContent = "Loading...";
+    fetch("/affirmations/random")
+      .then((response) => response.json())
+      .then((data) => {
+        const affirmation = data.affirmation;
+        affirmationElement.textContent = affirmation;
+      })
+      .catch(() => {
+        affirmationElement.textContent = "Failed to load affirmation.";
+      });
+  }
+}

--- a/app/templates/_header.html
+++ b/app/templates/_header.html
@@ -17,7 +17,7 @@
     </div>
     {% elif current_user.is_authenticated %}
     <div class="nav__menu">
-      <button onclick="navDropdown()" class="nav__name">Username</button>
+      <button onclick="navDropdown()" class="nav__name">{{ current_user.username }}</button>
       <button onclick="navDropdown()">
         <img src="{{ url_for('static', filename='images/profile_img.svg') }}" alt="User profile" class="nav__img">
       </button>

--- a/app/templates/affirmations/add.html
+++ b/app/templates/affirmations/add.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %} {% block title %} Affirmations {% endblock %} {% block
 content %}
 
-<form method="POST" action="{{ url_for('root.add_affirmation') }}">
+<form method="POST" action="{{ url_for('affirmations.add_affirmation') }}">
   <p><label for="affirmation_text">Affirmation:</label></p>
   <textarea
     id="affirmation_text"
@@ -18,7 +18,8 @@ Add your affirmation here</textarea
 </form>
 
 <p>
-  See all affirmations <a href="{{ url_for('root.affirmations') }}">here</a>
+  See all affirmations
+  <a href="{{ url_for('affirmations.affirmations') }}">here</a>
 </p>
 
 {% endblock %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -2,37 +2,54 @@
 %}
 <h1 class="page-title">Login</h1>
 
-{% with messages = get_flashed_messages(with_categories=true) %} {% if messages
-%} {% for category, message in messages %}
-<div>{{ message }}</div>
-{% endfor %} {% endif %} {% endwith %}
-
 <form method="POST" action="{{ url_for('auth.login') }}">
   <div class="form__group">
     <label for="username" class="form__label">Username:</label>
-    <input type="text" id="username" name="username" class="form__input" required />
+    <input
+      type="text"
+      id="username"
+      name="username"
+      class="form__input"
+      required
+    />
   </div>
 
   <div class="form__group">
     <label for="password" class="form__label">Password:</label>
-    <input type="password" id="password" name="password" class="form__input" required />
+    <input
+      type="password"
+      id="password"
+      name="password"
+      class="form__input"
+      required
+    />
   </div>
 
   <div class="form__group form__group--checkbox">
-    <input type="checkbox" id="remember" name="remember" class="form__checkbox"/>
-    <label for="remember" class="form__label form__label--checkbox">Remember me</label>
+    <input
+      type="checkbox"
+      id="remember"
+      name="remember"
+      class="form__checkbox"
+    />
+    <label for="remember" class="form__label form__label--checkbox"
+      >Remember me</label
+    >
   </div>
 
   <button type="submit" class="form__button btn">Login</button>
 </form>
 
 <div>
-  <a href="{{ url_for('auth.reset_password') }}" class="form__link">Forgot your password?</a>
+  <a href="{{ url_for('auth.reset_password_request') }}" class="form__link"
+    >Forgot your password?</a
+  >
 </div>
 
 <div>
-  <a href="{{ url_for('auth.register') }}" class="form__link">Don't have an account? Register here</a>
+  <a href="{{ url_for('auth.register') }}" class="form__link"
+    >Don't have an account? Register here</a
+  >
 </div>
-
 
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
       rel="stylesheet"
       href="{{ url_for('static', filename='styles/home.css') }}"
     />
-     <link
+    <link
       rel="stylesheet"
       href="{{ url_for('static', filename='styles/auth.css') }}"
     />
@@ -26,7 +26,7 @@
       messages %} {% for category, message in messages %}
       <div>
         {{ message }}
-        <button type="button">×</button>
+        <button type="button" onclick="this.parentElement.remove()">×</button>
       </div>
       {% endfor %} {% endif %} {% endwith %} {% block content %}{% endblock %}
     </main>

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -5,9 +5,11 @@ content %}
   {% if current_user.is_authenticated %}
   <h1>Welcome Back, {{ current_user.name }}!</h1>
   <p>You are logged in as: {{ current_user.username }}</p>
-  <a class="home__btn" href="{{ url_for('root.dashboard') }}">Go to Dashboard</a>
+  <a class="home__btn" href="{{ url_for('root.dashboard') }}"
+    >Go to Dashboard</a
+  >
   <a class="" href="{{ url_for('auth.profile') }}">View Profile</a>
-  
+
   {% if current_user.is_admin %}
   <a href="{{ url_for('root.admin_dashboard') }}">Go to Admin Dashboard</a>
   {% endif %} {% else %}
@@ -18,8 +20,6 @@ content %}
     mindset.
   </p>
   {% endif %}
-  
-  <p>Current time: {{ current_time }}</p>
 </section>
 
 <section class="home__section home__affirms">
@@ -35,17 +35,21 @@ content %}
         <figcaption class="affirm__cats">Self Care, Emotion</figcaption>
       </figure>
       <div class="affirm__btn--wrapper">
-        <button class="affirm__btn" aria-label="Save affirmation">+</button>
+        <button
+          class="affirm__btn"
+          aria-label="Save affirmation"
+          onclick="saveAffirmation('{{ affirmation.affirmation_id }}')"
+        >
+          +
+        </button>
         <p>
-          {% if current_user.is_authenticated %}
-            Save this affirmation
-          {% else %}
-            <a href="{{ url_for('auth.login') }}">Log in</a> to save this affirmation
-          {% endif %}
+          {% if current_user.is_authenticated %} Save this affirmation {% else%}
+          <a href="{{ url_for('auth.login') }}">Log in</a> to save this
+          affirmation {% endif %}
         </p>
       </div>
     </div>
-    {% endfor %}    
+    {% endfor %}
   </div>
 </section>
 
@@ -57,16 +61,17 @@ content %}
     <a class="home__btn" href="#">Submit Affirmations</a>
   </div>
   <div class="home__section">
-    {% for affirmation in all_affirmations[:1] %} 
+    {% for affirmation in all_affirmations[:1] %}
     <figure class="affirm__wrapper">
-      <blockquote class="affirm__quote">
+      <blockquote class="affirm__quote" id="random-affirmation">
         {{ affirmation.affirmation_text }}
       </blockquote>
       <figcaption class="affirm__cats">Self Worth</figcaption>
     </figure>
     {% endfor %}
-    <button class="home__btn">Get Affirmation</button>
+    <button class="home__btn" onclick="getRandomAffirmation()">
+      Get Affirmation
+    </button>
   </div>
 </section>
-{% endif %}
-{% endblock %}
+{% endif %} {% endblock %}

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 
-from app import create_app
+from app import create_app, db
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -13,6 +13,9 @@ if not os.environ.get("DATABASE_URL"):
 def main():
     """Main function to run the flask application."""
     app = create_app()
+
+    with app.app_context():
+        db.create_all()
 
     host = os.environ.get("FLASK_HOST", "0.0.0.0")
     port = int(os.environ.get("FLASK_PORT", 8000))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "bcrypt>=4.3.0",
     "flask>=2.3.0",
     "flask-login>=0.6.3",
+    "flask-mail>=0.10.0",
     "flask-sqlalchemy>=3.1.1",
     "psycopg2>=2.9.10",
     "python-dotenv>=1.0.0",

--- a/schema.sql
+++ b/schema.sql
@@ -1,9 +1,9 @@
 CREATE TABLE users (
     user_id SERIAL PRIMARY KEY,
-    name VARCHAR NOT NULL,
-    username VARCHAR NOT NULL UNIQUE,
-    email VARCHAR NOT NULL UNIQUE,
-    password_hash VARCHAR NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
     is_email_opt_in BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW()
@@ -11,7 +11,7 @@ CREATE TABLE users (
 
 CREATE TABLE roles (
     role_id SERIAL PRIMARY KEY,
-    name VARCHAR NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL UNIQUE,
     description TEXT,
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW()
@@ -25,9 +25,8 @@ CREATE TABLE user_roles (
 
 CREATE TABLE categories (
     category_id SERIAL PRIMARY KEY,
-    name VARCHAR NOT NULL,
-    user_id INT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    is_admin_set BOOLEAN DEFAULT FALSE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW()
 );
@@ -55,4 +54,10 @@ CREATE TABLE daily_mail_history (
     affirmation_id INT NOT NULL REFERENCES affirmations(affirmation_id) ON DELETE CASCADE,
     sent_email_at TIMESTAMP,
     scheduled_for TIMESTAMP
+);
+
+CREATE TABLE saved_affirmations (
+    saved_affirmation_id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    affirmation_id INT NOT NULL REFERENCES affirmations(affirmation_id) ON DELETE CASCADE
 );

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,43 @@ wheels = [
 ]
 
 [[package]]
+name = "dailydose"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "flask" },
+    { name = "flask-login" },
+    { name = "flask-mail" },
+    { name = "flask-sqlalchemy" },
+    { name = "psycopg2" },
+    { name = "python-dotenv" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
+    { name = "flake8" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bcrypt", specifier = ">=4.3.0" },
+    { name = "flask", specifier = ">=2.3.0" },
+    { name = "flask-login", specifier = ">=0.6.3" },
+    { name = "flask-mail", specifier = ">=0.10.0" },
+    { name = "flask-sqlalchemy", specifier = ">=3.1.1" },
+    { name = "psycopg2", specifier = ">=2.9.10" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=25.1.0" },
+    { name = "flake8", specifier = ">=7.3.0" },
+]
+
+[[package]]
 name = "flake8"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -148,6 +185,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/6e/2f4e13e373bb49e68c02c51ceadd22d172715a06716f9299d9df01b6ddb2/Flask-Login-0.6.3.tar.gz", hash = "sha256:5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333", size = 48834, upload-time = "2023-10-30T14:53:21.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl", hash = "sha256:849b25b82a436bf830a054e74214074af59097171562ab10bfa999e6b78aae5d", size = 17303, upload-time = "2023-10-30T14:53:19.636Z" },
+]
+
+[[package]]
+name = "flask-mail"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "flask" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/29/e92dc84c675d1e8d260d5768eb3fb65c70cbd33addecf424187587bee862/flask_mail-0.10.0.tar.gz", hash = "sha256:44083e7b02bbcce792209c06252f8569dd5a325a7aaa76afe7330422bd97881d", size = 8152, upload-time = "2024-05-23T22:30:12.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/c0/a81083da779f482494d49195d8b6c9fde21072558253e4a9fb2ec969c3c1/flask_mail-0.10.0-py3-none-any.whl", hash = "sha256:a451e490931bb3441d9b11ebab6812a16bfa81855792ae1bf9c1e1e22c4e51e7", size = 8529, upload-time = "2024-05-23T22:30:10.962Z" },
 ]
 
 [[package]]
@@ -194,41 +244,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
-]
-
-[[package]]
-name = "dailydose"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "bcrypt" },
-    { name = "flask" },
-    { name = "flask-login" },
-    { name = "flask-sqlalchemy" },
-    { name = "psycopg2" },
-    { name = "python-dotenv" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "black" },
-    { name = "flake8" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "bcrypt", specifier = ">=4.3.0" },
-    { name = "flask", specifier = ">=2.3.0" },
-    { name = "flask-login", specifier = ">=0.6.3" },
-    { name = "flask-sqlalchemy", specifier = ">=3.1.1" },
-    { name = "psycopg2", specifier = ">=2.9.10" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "black", specifier = ">=25.1.0" },
-    { name = "flake8", specifier = ">=7.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **feat: add reset password email notifications and moved affirmations CRUD to different file**

#### **Changes**

* integrate Flask-Mail for sending emails (password reset)
* implement password reset functionality with email notifications
* moved affirmations routes to different file from `root.py` to `affirmations.py`
* update user and category table schemas with length constraints
* display current user's username in nav menu
* restrict admin dashboard access for non-admin users
* clean up unused affirmation routes
* improve HTML structure and button functionalities
* add email config to `.env.example`
* increase flake8 max line length to 100

#60 close
