### PR TITLE
feat: Style Affirmation Pages

### DIFF
--- a/app/static/styles/affirmations.css
+++ b/app/static/styles/affirmations.css
@@ -54,6 +54,11 @@
   margin-top: 0.5em;
 }
 
+form .affirm__action,
+form .affirm__edit {
+  margin-top: 1em;
+}
+
 .affirm__edit,
 .affirm__delete {
   border: none;

--- a/app/static/styles/affirmations.css
+++ b/app/static/styles/affirmations.css
@@ -38,3 +38,21 @@
   padding: 0.25em 0.5em;
 }
 
+.affirm__edit,
+.affirm__delete {
+  border: none;
+  border-radius: 0.4em;
+  padding: 0.5em;
+  font-size: 0.9em;
+  color: var(--white);
+  text-decoration: none;
+}
+
+.affirm__edit {
+  background-color: var(--edit-btn-clr);
+}
+
+.affirm__delete {
+  background-color: var(--delete-btn-clr);
+}
+

--- a/app/static/styles/affirmations.css
+++ b/app/static/styles/affirmations.css
@@ -38,6 +38,22 @@
   padding: 0.25em 0.5em;
 }
 
+.affirm__action {
+  text-align: center;
+  text-decoration: none;
+  display: block;
+  padding: 1em;
+  background-color: var(--purple-dark);
+  color: var(--white);
+  border: none;
+  border-radius: 0.75em;
+  width: 100%;
+}
+
+.affirm__action + .affirm__action {
+  margin-top: 0.5em;
+}
+
 .affirm__edit,
 .affirm__delete {
   border: none;
@@ -54,5 +70,9 @@
 
 .affirm__delete {
   background-color: var(--delete-btn-clr);
+}
+
+.affirm__section--bottom {
+  margin-top: 3em;
 }
 

--- a/app/static/styles/affirmations.css
+++ b/app/static/styles/affirmations.css
@@ -1,0 +1,40 @@
+.affirms__wrapper {
+  display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%/1, max(15rem, 100%/4)), 1fr));
+	gap: 1em;
+}
+
+.affirm__wrapper {
+  padding: 1em;
+  border: 3px solid var(--purple-outline);
+  border-radius: 1em;
+  background-color: var(--white);
+}
+
+.affirm__quote {
+  text-align: center;
+  font-size: 1.5em;
+  padding: 1em 0;
+  color: var(--purple-dark);
+}
+
+.affirm__cats {
+  font-size: 0.9em;
+}
+
+.affirm__btn--wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  margin-top: 0.5em;
+  align-items: center;
+}
+
+.affirm__btn {
+  background-color: var(--save-btn-clr);
+  color: var(--white);
+  border: none;
+  border-radius: 0.3em;
+  padding: 0.25em 0.5em;
+}
+

--- a/app/static/styles/affirmations.css
+++ b/app/static/styles/affirmations.css
@@ -50,13 +50,13 @@
   width: 100%;
 }
 
-.affirm__action + .affirm__action {
-  margin-top: 0.5em;
-}
-
-form .affirm__action,
+* + .affirm__action,
 form .affirm__edit {
   margin-top: 1em;
+}
+
+.affirm__action + .affirm__action {
+  margin-top: 0.5em;
 }
 
 .affirm__edit,

--- a/app/static/styles/home.css
+++ b/app/static/styles/home.css
@@ -11,10 +11,6 @@
   text-align: center;
 }
 
-.home__hero h1 {
-  margin-bottom: 0.5em;
-}
-
 .home__save-affirms {
   text-align: center;
   background-color: var(--purple-outline);

--- a/app/static/styles/home.css
+++ b/app/static/styles/home.css
@@ -15,19 +15,3 @@
   text-align: center;
   background-color: var(--purple-outline);
 }
-
-.home__btn {
-  text-align: center;
-  text-decoration: none;
-  display: block;
-  padding: 1em;
-  background-color: var(--purple-dark);
-  color: var(--white);
-  border: none;
-  border-radius: 0.75em;
-  width: 100%;
-}
-
-.home__btn + .home__btn {
-  margin-top: 0.5em;
-}

--- a/app/static/styles/home.css
+++ b/app/static/styles/home.css
@@ -20,45 +20,6 @@
   background-color: var(--purple-outline);
 }
 
-.affirms__wrapper {
-  display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(min(100%/1, max(15rem, 100%/4)), 1fr));
-	gap: 1em;
-}
-
-.affirm__wrapper {
-  padding: 1em;
-  border: 3px solid var(--purple-outline);
-  border-radius: 1em;
-  background-color: var(--white);
-}
-
-.affirm__quote {
-  text-align: center;
-  font-size: 1.5em;
-  padding: 1em 0;
-  color: var(--purple-dark);
-}
-
-.affirm__cats {
-  font-size: 0.9em;
-}
-
-.affirm__btn--wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5em;
-  margin-top: 0.5em;
-}
-
-.affirm__btn {
-  background-color: var(--save-btn-clr);
-  color: var(--white);
-  border: none;
-  border-radius: 0.3em;
-  padding: 0.25em 0.5em;
-}
-
 .home__btn {
   text-align: center;
   text-decoration: none;

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -10,7 +10,7 @@
   --red-important-hover: #681414;
   --edit-btn-clr: #008000;
   --delete-btn-clr: #c20000;
-  font-family: Nunito, Arial, sans-serif;
+  font-family: "Nunito", Arial, sans-serif;
   scroll-behavior: smooth;
 }
 

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -8,6 +8,8 @@
   --txt-fade-clr: #4c4c4c;
   --red-important: #BD4545;
   --red-important-hover: #681414;
+  --edit-btn-clr: #008000;
+  --delete-btn-clr: #c20000;
   font-family: Nunito, Arial, sans-serif;
   scroll-behavior: smooth;
 }

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -66,6 +66,7 @@ main {
 
 h1 {
   font-size: 3rem;
+  margin-bottom: 0.5em;
 }
 
 /* Mobile-first design - minimum 300px screen width */

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -8,23 +8,14 @@
   --txt-fade-clr: #4c4c4c;
   --red-important: #BD4545;
   --red-important-hover: #681414;
+  font-family: Nunito, Arial, sans-serif;
+  scroll-behavior: smooth;
 }
 
 * {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-}
-
-:root {
-  --body-bg-clr: #F0EAF4;
-  --purple-dark: #4D317A;
-  --purple-light: #8B66C6;
-  --purple-outline: #C7C2E1;
-  --red-important: #BD4545;
-  --red-important-hover: #681414;
-  font-family: Nunito, Arial, sans-serif;
-  scroll-behavior: smooth;
 }
 
 body {

--- a/app/templates/affirmations/add.html
+++ b/app/templates/affirmations/add.html
@@ -1,24 +1,25 @@
 {% extends "base.html" %} {% block title %} Affirmations {% endblock %} {% block
 content %}
 
+<h1>Add Affirmation</h1>
+
 <form method="POST" action="{{ url_for('affirmations.add_affirmation') }}">
-  <p><label for="affirmation_text">Affirmation:</label></p>
+  <p><label for="affirmation_text">Add your affirmation:</label></p>
   <textarea
     id="affirmation_text"
     name="affirmation_text"
     rows="4"
     cols="50"
+    class="form__input"
     required
   >
-Add your affirmation here</textarea
-  >
-  <br />
+  </textarea>
 
-  <button type="submit">Submit</button>
+  <button type="submit" class="affirm__action">Submit</button>
 </form>
 
-<p>
-  <a href="{{ url_for('affirmations.affirmations') }}">See all affirmations</a>
-</p>
+<section class="affirm__section--bottom">
+  <a href="{{ url_for('affirmations.affirmations') }}" class="affirm__action">See all affirmations</a>
+</section>
 
 {% endblock %}

--- a/app/templates/affirmations/add.html
+++ b/app/templates/affirmations/add.html
@@ -18,8 +18,7 @@ Add your affirmation here</textarea
 </form>
 
 <p>
-  See all affirmations
-  <a href="{{ url_for('affirmations.affirmations') }}">here</a>
+  <a href="{{ url_for('affirmations.affirmations') }}">See all affirmations</a>
 </p>
 
 {% endblock %}

--- a/app/templates/affirmations/edit.html
+++ b/app/templates/affirmations/edit.html
@@ -3,7 +3,7 @@ content %}
 
 <form
   method="POST"
-  action="{{ url_for('root.edit_affirmation', affirmation_id=affirmation.affirmation_id) }}"
+  action="{{ url_for('affirmations.edit_affirmation', affirmation_id=affirmation.affirmation_id) }}"
 >
   <p><label for="affirmation_text">Affirmation:</label></p>
   <textarea

--- a/app/templates/affirmations/edit.html
+++ b/app/templates/affirmations/edit.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %} {% block title %} Affirmations {% endblock %} {% block
 content %}
 
+<h1>Edit Affirmation</h1>
+
 <form
   method="POST"
   action="{{ url_for('affirmations.edit_affirmation', affirmation_id=affirmation.affirmation_id) }}"
@@ -11,11 +13,11 @@ content %}
     name="affirmation_text"
     rows="4"
     cols="50"
+    class="form__input"
     required
   >
 {{ affirmation.affirmation_text }}</textarea
   >
-  <br />
 
   <button type="submit" class="affirm__edit">Edit</button>
 </form>

--- a/app/templates/affirmations/edit.html
+++ b/app/templates/affirmations/edit.html
@@ -17,7 +17,7 @@ content %}
   >
   <br />
 
-  <button type="submit">Edit</button>
+  <button type="submit" class="affirm__edit">Edit</button>
 </form>
 
 {% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -18,5 +18,5 @@ content %}
     {% endif %}
 </p>
 {% endfor %}
-<p>Add affirmation <a href="{{ url_for('affirmations.add_affirmation') }}">here</a></p>
+<p><a href="{{ url_for('affirmations.add_affirmation') }}">Add affirmation</a></p>
 {% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -5,7 +5,7 @@ content %}
 {% for affirmation in all_affirmations %}
 <p>
   <a
-    href="{{ url_for('root.edit_affirmation', affirmation_id=affirmation.affirmation_id)}}"
+    href="{{ url_for('affirmations.edit_affirmation', affirmation_id=affirmation.affirmation_id)}}"
     >{{ affirmation.affirmation_text }} 
   </a>
     {% if affirmation.user_id == user.user_id %}
@@ -18,5 +18,5 @@ content %}
     {% endif %}
 </p>
 {% endfor %}
-<p>Add affirmation <a href="{{ url_for('root.add_affirmation') }}">here</a></p>
+<p>Add affirmation <a href="{{ url_for('affirmations.add_affirmation') }}">here</a></p>
 {% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -11,7 +11,7 @@ content %}
     {% if affirmation.user_id == user.user_id %}
     <form
       method="POST"
-      action="{{ url_for('root.delete_affirmation', affirmation_id=affirmation.affirmation_id) }}"
+      action="{{ url_for('affirmations.delete_affirmation', affirmation_id=affirmation.affirmation_id) }}"
     >
       <button type="submit">Delete</button>
     </form>

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -2,7 +2,7 @@
 content %}
 <h1>Affirmations</h1>
 
-<div class="affirms__wrapper">
+<section class="affirms__wrapper">
   {% for affirmation in all_affirmations %}
   <div class="affirm">
     <figure class="affirm__wrapper">
@@ -32,6 +32,9 @@ content %}
     {% endif %}
   </div>
   {% endfor %}
-</div>
-<p><a href="{{ url_for('affirmations.add_affirmation') }}">Add affirmation</a></p>
+</section>
+
+<section class="affirm__section--bottom">
+  <a href="{{ url_for('affirmations.add_affirmation') }}" class="affirm__action">Add affirmation</a>
+</section>
 {% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -2,21 +2,35 @@
 content %}
 <h1>Affirmations</h1>
 
-{% for affirmation in all_affirmations %}
-<p>
-  <a
-    href="{{ url_for('affirmations.edit_affirmation', affirmation_id=affirmation.affirmation_id)}}"
-    >{{ affirmation.affirmation_text }} 
-  </a>
-    {% if affirmation.user_id == user.user_id %}
-    <form
-      method="POST"
-      action="{{ url_for('affirmations.delete_affirmation', affirmation_id=affirmation.affirmation_id) }}"
-    >
-      <button type="submit">Delete</button>
-    </form>
+<div class="affirms__wrapper">
+  {% for affirmation in all_affirmations %}
+  <div class="affirm">
+    <figure class="affirm__wrapper">
+      <blockquote class="affirm__quote">
+        {{ affirmation.affirmation_text }} 
+      </blockquote>
+      <figcaption class="affirm__cats">
+        {% for category in affirmation.categories %}
+          {{ category.category.name }}
+        {% endfor %}
+      </figcaption>
+    </figure>
+    <div class="affirm__btn--wrapper">
+      <a
+        href="{{ url_for('affirmations.edit_affirmation', affirmation_id=affirmation.affirmation_id)}}"
+        >Edit
+      </a>
+      {% if affirmation.user_id == user.user_id %}
+      <form
+        method="POST"
+        action="{{ url_for('affirmations.delete_affirmation', affirmation_id=affirmation.affirmation_id) }}"
+      >
+        <button type="submit">Delete</button>
+      </form>
+    </div>
     {% endif %}
-</p>
-{% endfor %}
+  </div>
+  {% endfor %}
+</div>
 <p><a href="{{ url_for('affirmations.add_affirmation') }}">Add affirmation</a></p>
 {% endblock %}

--- a/app/templates/affirmations/index.html
+++ b/app/templates/affirmations/index.html
@@ -18,6 +18,7 @@ content %}
     <div class="affirm__btn--wrapper">
       <a
         href="{{ url_for('affirmations.edit_affirmation', affirmation_id=affirmation.affirmation_id)}}"
+        class="affirm__edit"
         >Edit
       </a>
       {% if affirmation.user_id == user.user_id %}
@@ -25,7 +26,7 @@ content %}
         method="POST"
         action="{{ url_for('affirmations.delete_affirmation', affirmation_id=affirmation.affirmation_id) }}"
       >
-        <button type="submit">Delete</button>
+        <button class="affirm__delete" type="submit">Delete</button>
       </form>
     </div>
     {% endif %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,6 +20,8 @@
       rel="stylesheet"
       href="{{ url_for('static', filename='styles/auth.css') }}"
     />
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
     <script src="{{ url_for('static', filename='scripts/index.js') }}"></script>
   </head>
   <body>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,10 @@
     />
     <link
       rel="stylesheet"
+      href="{{ url_for('static', filename='styles/affirmations.css') }}"
+    />
+    <link
+      rel="stylesheet"
       href="{{ url_for('static', filename='styles/auth.css') }}"
     />
     <script src="{{ url_for('static', filename='scripts/index.js') }}"></script>

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -5,7 +5,7 @@ content %}
   {% if current_user.is_authenticated %}
   <h1>Welcome Back, {{ current_user.name }}!</h1>
   <p>You are logged in as: {{ current_user.username }}</p>
-  <a class="home__btn" href="{{ url_for('root.dashboard') }}"
+  <a class="affirm__action" href="{{ url_for('root.dashboard') }}"
     >Go to Dashboard</a
   >
   <a class="" href="{{ url_for('auth.profile') }}">View Profile</a>
@@ -60,8 +60,8 @@ content %}
 <section class="home__save-affirms">
   <div class="home__section">
     <h2>Keep words that matter to you here.</h2>
-    <a class="home__btn" href="{{ url_for('affirmations.affirmations') }}">View Affirmations</a>
-    <a class="home__btn" href="{{ url_for('affirmations.add_affirmation') }}">Submit Affirmations</a>
+    <a class="affirm__action" href="{{ url_for('affirmations.affirmations') }}">View Affirmations</a>
+    <a class="affirm__action" href="{{ url_for('affirmations.add_affirmation') }}">Submit Affirmations</a>
   </div>
   <div class="home__section">
     {% for affirmation in all_affirmations[:1] %}
@@ -72,7 +72,7 @@ content %}
       <figcaption class="affirm__cats">Self Worth</figcaption>
     </figure>
     {% endfor %}
-    <button class="home__btn" onclick="getRandomAffirmation()">
+    <button class="affirm__action" onclick="getRandomAffirmation()">
       Get Affirmation
     </button>
   </div>

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -31,8 +31,11 @@ content %}
         <blockquote class="affirm__quote">
           {{ affirmation.affirmation_text }}
         </blockquote>
-        <!-- We may use Jinja for loop for displaying the categories of this affirmation -->
-        <figcaption class="affirm__cats">Self Care, Emotion</figcaption>
+        <figcaption class="affirm__cats">
+          {% for category in affirmation.categories %}
+            {{ category.category.name }}
+          {% endfor %}
+        </figcaption>
       </figure>
       <div class="affirm__btn--wrapper">
         <button

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -8,10 +8,10 @@ content %}
   <a class="affirm__action" href="{{ url_for('root.dashboard') }}"
     >Go to Dashboard</a
   >
-  <a class="" href="{{ url_for('auth.profile') }}">View Profile</a>
+  <a class="affirm__action" href="{{ url_for('auth.profile') }}">View Profile</a>
 
   {% if current_user.is_admin %}
-  <a href="{{ url_for('root.admin_dashboard') }}">Go to Admin Dashboard</a>
+  <a class="affirm__action" href="{{ url_for('root.admin_dashboard') }}">Go to Admin Dashboard</a>
   {% endif %} {% else %}
   <h1>Welcome to DailyDose</h1>
   <h2>Your Personal Affirmation Journey</h2>

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -61,7 +61,7 @@ content %}
   <div class="home__section">
     <h2>Keep words that matter to you here.</h2>
     <a class="affirm__action" href="{{ url_for('affirmations.affirmations') }}">View Affirmations</a>
-    <a class="affirm__action" href="{{ url_for('affirmations.add_affirmation') }}">Submit Affirmations</a>
+    <a class="affirm__action" href="{{ url_for('affirmations.add_affirmation') }}">Add Affirmation</a>
   </div>
   <div class="home__section">
     {% for affirmation in all_affirmations[:1] %}

--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -57,8 +57,8 @@ content %}
 <section class="home__save-affirms">
   <div class="home__section">
     <h2>Keep words that matter to you here.</h2>
-    <a class="home__btn" href="#">View Affirmations</a>
-    <a class="home__btn" href="#">Submit Affirmations</a>
+    <a class="home__btn" href="{{ url_for('affirmations.affirmations') }}">View Affirmations</a>
+    <a class="home__btn" href="{{ url_for('affirmations.add_affirmation') }}">Submit Affirmations</a>
   </div>
   <div class="home__section">
     {% for affirmation in all_affirmations[:1] %}


### PR DESCRIPTION
Resolves https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class/issues/62.

I created a CSS stylesheet for the affirmations, fixed affirmation routes, improved the HTML syntax of the Jinja templates, and replaced the hard-coded categories of each affirmation with Jinja for loop.

In addition to styling the affirmation pages, I made improvements to the general style of the front end, by embedding Nunito font with [Bunny Fonts](https://fonts.bunny.net/), a privacy-respecting drop-in replacement for Google Fonts, and add the appropriate routes to the links to perform actions related to the affirmations.