### PR TITLE
Fix: Header logo fix & Footer removal in Login / Register / Reset Password pages

### DIFF
--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -51,7 +51,7 @@ main {
   padding: 1.5rem 1.5rem;
 }
 
-header {
+.header__top {
   width: 100%;
   position: fixed;
   top: 0;

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -77,6 +77,7 @@ h1 {
   height: 3.5rem;
   text-align: center;
   align-items: center;
+  justify-content: center;
   font-size: 0.8rem;
   overflow: visible;
   padding: 0.3rem;

--- a/app/templates/_footer.html
+++ b/app/templates/_footer.html
@@ -1,14 +1,13 @@
 <footer>
-  {% if current_user.is_authenticated %}
+  {% if current_user.is_authenticated 
+    or request.path == url_for('auth.login') 
+    or request.path == url_for('auth.register')
+    or request.path == url_for('auth.reset_password_request') %}
   <section>
     <a href="{{ url_for('root.index') }}"><img src="{{ url_for('static', filename='images/logo_white.svg') }}" alt="DailyDose logo" class="footer__logo"></a>
     <button class="footer__totop--button" type="button" onclick="toTop()">Back to top</button>
   </section>
   <address>Developed by <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class">indigo-class</a>, team of <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon">freeCodeCamp 2025 Summer Hackathon</a>.</address>
-  {% elif request.path == url_for('auth.login') %}
-  {% elif request.path == url_for('auth.register') %}
-  {% elif request.path == url_for('auth.reset_password_request') %}
-  <!-- {# This makes footer only a purple bar for footer since the 3 pages don't need the CTAs #} -->
   {% else %}
   <section class="footer__register">
     <p class="footer__register--slogan">Peace is a click away</p>

--- a/app/templates/_footer.html
+++ b/app/templates/_footer.html
@@ -1,5 +1,14 @@
 <footer>
   {% if current_user.is_authenticated %}
+  <section>
+    <a href="{{ url_for('root.index') }}"><img src="{{ url_for('static', filename='images/logo_white.svg') }}" alt="DailyDose logo" class="footer__logo"></a>
+    <button class="footer__totop--button" type="button" onclick="toTop()">Back to top</button>
+  </section>
+  <address>Developed by <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class">indigo-class</a>, team of <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon">freeCodeCamp 2025 Summer Hackathon</a>.</address>
+  {% elif request.path == url_for('auth.login') %}
+  {% elif request.path == url_for('auth.register') %}
+  <!-- TODO: Need to add reset password page url when ready -->
+  <!-- This makes footer only a purple bar for footer since the 3 pages don't need the CTAs -->
   {% else %}
   <section class="footer__register">
     <p class="footer__register--slogan">Peace is a click away</p>
@@ -7,10 +16,10 @@
     <a href="{{ url_for('auth.register') }}" class="footer__register--button">Register now</a>
     <p class="login__prompt">Have an account already? <a href="{{ url_for('auth.login') }}">Log in</a></p>
   </section>
-  {% endif %}
   <section>
     <a href="{{ url_for('root.index') }}"><img src="{{ url_for('static', filename='images/logo_white.svg') }}" alt="DailyDose logo" class="footer__logo"></a>
     <button class="footer__totop--button" type="button" onclick="toTop()">Back to top</button>
   </section>
   <address>Developed by <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class">indigo-class</a>, team of <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon">freeCodeCamp 2025 Summer Hackathon</a>.</address>
+  {% endif %}
 </footer>

--- a/app/templates/_footer.html
+++ b/app/templates/_footer.html
@@ -7,8 +7,8 @@
   <address>Developed by <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class">indigo-class</a>, team of <a href="https://github.com/freeCodeCamp-2025-Summer-Hackathon">freeCodeCamp 2025 Summer Hackathon</a>.</address>
   {% elif request.path == url_for('auth.login') %}
   {% elif request.path == url_for('auth.register') %}
-  <!-- TODO: Need to add reset password page url when ready -->
-  <!-- This makes footer only a purple bar for footer since the 3 pages don't need the CTAs -->
+  {% elif request.path == url_for('auth.reset_password_request') %}
+  <!-- {# This makes footer only a purple bar for footer since the 3 pages don't need the CTAs #} -->
   {% else %}
   <section class="footer__register">
     <p class="footer__register--slogan">Peace is a click away</p>

--- a/app/templates/_header.html
+++ b/app/templates/_header.html
@@ -1,4 +1,4 @@
-<header>
+<header class="header__top">
   <nav class="nav__top">
     <a href="{{ url_for('root.index') }}"><img src="{{ url_for('static', filename='images/logo_white.svg') }}" alt="DailyDose logo" class="nav__logo"></a>
     {% if current_user.is_authenticated and current_user.is_admin() %}

--- a/app/templates/_header.html
+++ b/app/templates/_header.html
@@ -14,7 +14,7 @@
       <a href="{{ url_for('root.admin_dashboard') }}" class="nav__menu--button{% if request.path == url_for('root.admin_dashboard') %} active{% endif %}">Affirmations</a>
       <a href="{{ url_for('root.admin_dashboard') }}" class="nav__menu--button{% if request.path == url_for('root.admin_dashboard') %} active{% endif %}">Settings</a>
       <a href="{{ url_for('auth.logout') }}" class="nav__menu--button logout">Logout</a>
-    </div>
+    </nav>
     {% elif current_user.is_authenticated %}
     <div class="nav__menu">
       <button onclick="navDropdown()" class="nav__name">Username</button>


### PR DESCRIPTION
Closes #58 

Footer is now just a plain purple bar for login / register / reset password pages as the call-to-actions are not needed on those three pages.

In addition, header logo is now centralized on desktop.
(Logo stays left on mobile; this is intentional to make space for the username and dropdown menu)