### PR TITLE
hotfix: Re-add Jinja conditions for user-specfici sections on the home page

### DIFF
--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -39,6 +39,7 @@ content %}
         </figcaption>
       </figure>
       <div class="affirm__btn--wrapper">
+        {% if current_user.is_authenticated %}
         <button
           class="affirm__btn"
           aria-label="Save affirmation"
@@ -46,8 +47,9 @@ content %}
         >
           +
         </button>
+        {% endif %}
         <p>
-          {% if current_user.is_authenticated %} Save this affirmation {% else%}
+          {% if current_user.is_authenticated %} Save this affirmation {% else %}
           <a href="{{ url_for('auth.login') }}">Log in</a> to save this
           affirmation {% endif %}
         </p>


### PR DESCRIPTION
In our attempt to allow non-users to get affirmations by creating the pull request https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class/pull/72, we ended up removing almost all conditions to check if the user is logged in from the `home/index.html` template, which was not how it was supposed to be done, since there are other parts on the page that should only be visible to users who are logged in.

This PR re-adds Jinja conditions for specific sections of the home page, so they would only be visible to users who have logged in, while still keep the "Get Affirmation" button visisble to non-users.