### PR TITLE
fix: Fix typo in Jinja condition for displaying affirmation links

### DIFF
--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -60,7 +60,7 @@ content %}
 </section>
 
 <section class="home__save-affirms">
-  {% if current_user.is_authenticate %}    
+  {% if current_user.is_authenticated %}
   <div class="home__section">
     <h2>Keep words that matter to you here.</h2>
     <a class="affirm__action" href="{{ url_for('affirmations.affirmations') }}">View Affirmations</a>


### PR DESCRIPTION
There is a typo in the `{% if current_user.is_authenticated %}` condition in the `home/index.html` Jinja template that causes the section containing links to view and add affirmations to not be displayed, even if the user has logged in. This PR fixes the typo in the Jinja condition.