### PR TITLE
fix(page title): match with wireframe (refs #93) 

### DIFF
--- a/app/static/styles/base/base.css
+++ b/app/static/styles/base/base.css
@@ -37,9 +37,11 @@ body {
 }
 
 .page-title {
-  font-size: 4rem;
-  font-weight: 700;
-  color: #000;
+  padding: 0.5em 0;
+  font-size: 2.25rem;
+  font-weight: 400;
+  text-align: center;
+  color: #4d317a;
 }
 
 .header__top {


### PR DESCRIPTION
[Resolves #93](https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class/issues/93) 
Fixes page title style to match the wireframe.