### PR TITLE
fix/form-semantics-style

### DIFF
--- a/app/static/styles/components/form.css
+++ b/app/static/styles/components/form.css
@@ -41,7 +41,6 @@
   font-size: 0.8rem;
   color: var(--purple-dark);
   text-decoration: none;
-  text-align: center;
 }
 
 .form__link:hover{

--- a/app/static/styles/components/form.css
+++ b/app/static/styles/components/form.css
@@ -32,7 +32,7 @@
 
 .form__group--checkbox{
   display: flex;
-  justify-content: left;
+  justify-content: center;
   margin: 0.5rem 0 0;
   gap: 0.5rem;
 }

--- a/app/static/styles/components/form.css
+++ b/app/static/styles/components/form.css
@@ -41,6 +41,7 @@
   font-size: 0.8rem;
   color: var(--purple-dark);
   text-decoration: none;
+  padding-bottom: 0.5em;
 }
 
 .form__link:hover{

--- a/app/static/styles/components/form.css
+++ b/app/static/styles/components/form.css
@@ -46,5 +46,4 @@
 
 .form__link:hover{
   text-decoration: underline;
-  
 }

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -15,5 +15,6 @@
 /* Importing utility styles */
 @import './utilities/spacing.css';
 @import './utilities/colors.css';
+@import './utilities/alignment.css';
 /* Importing page-specific styles */
 @import './pages/home.css';

--- a/app/static/styles/utilities/alignment.css
+++ b/app/static/styles/utilities/alignment.css
@@ -1,0 +1,4 @@
+.center {
+    display: flex;
+    justify-content: center;
+}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -40,16 +40,16 @@
   <button type="submit" class="form__button btn">Login</button>
 </form>
 
-<div class="center">
+<p class="center">
   <a href="{{ url_for('auth.reset_password_request') }}" class="form__link"
     >Forgot your password?</a
   >
-</div>
+</p>
 
-<div class="center">
+<p class="center">
   <a href="{{ url_for('auth.register') }}" class="form__link"
     >Don't have an account? Register here</a
   >
-</div>
+</p>
 
 {% endblock %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -40,13 +40,13 @@
   <button type="submit" class="form__button btn">Login</button>
 </form>
 
-<div>
+<div class="center">
   <a href="{{ url_for('auth.reset_password_request') }}" class="form__link"
     >Forgot your password?</a
   >
 </div>
 
-<div>
+<div class="center">
   <a href="{{ url_for('auth.register') }}" class="form__link"
     >Don't have an account? Register here</a
   >

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -91,9 +91,9 @@
             </button>
         </form>
 
-        <div class="center">
+        <p class="center">
             <a href="{{ url_for('auth.login') }} " class="form__link">Have an existing account? Log in</a>
-        </div>
+        </p>
 
     </section>
 {% endblock %}

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -91,7 +91,7 @@
             </button>
         </form>
 
-        <div>
+        <div class="center">
             <a href="{{ url_for('auth.login') }} " class="form__link">Have an existing account? Log in</a>
         </div>
 

--- a/app/templates/auth/reset_password_request.html
+++ b/app/templates/auth/reset_password_request.html
@@ -27,9 +27,9 @@
         <button type="submit" class="form__button btn">Send password reset email</button>
     </form>
 
-    <div class="center">
+    <p class="center">
         <a href="{{ url_for('auth.login') }}" class="form__link">Have an existing account? Log in</a>
-    </div>
+    </p>
 </section>
 
 

--- a/app/templates/auth/reset_password_request.html
+++ b/app/templates/auth/reset_password_request.html
@@ -27,7 +27,7 @@
         <button type="submit" class="form__button btn">Send password reset email</button>
     </form>
 
-    <div>
+    <div class="center">
         <a href="{{ url_for('auth.login') }}" class="form__link">Have an existing account? Log in</a>
     </div>
 </section>


### PR DESCRIPTION
Resolves [96](https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class/issues/96)

- Centers form footer to match the wireframe
- Wraps form links in `<p>` elements
- Adds a gap between the footer paragraphs
- Adds a gap between the form footer and the page footer