### PR TITLE
feat(generated affirmations): add pin button to generated affirmations

### DIFF
--- a/app/templates/home/index.html
+++ b/app/templates/home/index.html
@@ -101,6 +101,15 @@ content %}
       {% endfor %}
     </figcaption>
   </figure>
+  <div class="padding--sm">
+  <button
+    class="btn btn--primary pin-affirmation"
+    aria-label="Pin"
+    onclick="updateActionType('{{ affirmation.id }}', 'pin')"
+  >
+    &plus;
+  </button>
+</div>
   {% endfor %}
   <button class="btn btn--block btn--primary" onclick="getRandomAffirmation()">
     Get Affirmation


### PR DESCRIPTION
Resolves [#156](https://github.com/freeCodeCamp-2025-Summer-Hackathon/indigo-class/issues/156) 

Adds pin button to generated affirmations.